### PR TITLE
Add android product flavors for websocket_uri

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,9 +16,6 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        // WebSocket connection URI
-        resValue "string", "websocket_uri", "ws://10.0.2.2:53211/monopoly"
     }
 
     buildTypes {
@@ -36,6 +33,20 @@ android {
         unitTests.all {
             useJUnitPlatform()
             finalizedBy jacocoTestReport
+        }
+    }
+
+    flavorDimensions 'websocket_uri'
+    productFlavors {
+        localhost {
+            dimension 'websocket_uri'
+            // WebSocket connection URI
+            resValue "string", "websocket_uri", "ws://10.0.2.2:53211/monopoly"
+        }
+        'se2-demo' {
+            dimension 'websocket_uri'
+            // WebSocket connection URI
+            resValue "string", "websocket_uri", "ws://se2-demo.aau.at:53211/monopoly"
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,7 +36,7 @@ android {
         }
     }
 
-    flavorDimensions 'websocket_uri'
+    flavorDimensions = ['websocket_uri']
     productFlavors {
         localhost {
             dimension 'websocket_uri'
@@ -52,7 +52,7 @@ android {
 }
 
 tasks.register('jacocoTestReport', JacocoReport) {
-    dependsOn "testDebugUnitTest"
+    dependsOn "testLocalhostDebugUnitTest"
     description = "Generate Jacoco coverage reports"
 
     reports {

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -2,5 +2,6 @@
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">se2-demo.aau.at</domain>
     </domain-config>
 </network-security-config>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,10 +7,10 @@ junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 appcompat = "1.6.1"
 lombok = "1.18.32"
-material = "1.11.0"
-activity = "1.8.2"
+material = "1.12.0"
+activity = "1.9.0"
 constraintlayout = "2.1.4"
-mockitoCore = "5.7.0"
+mockitoCore = "5.11.0"
 okhttp = "4.12.0"
 
 [libraries]


### PR DESCRIPTION
Adds the ability to select which server should be used for the WebSocket connection.
Fix #35 

Selection is possible under [Build Variants] (View -> Tool Windows -> Build Variants)
![Image](https://github.com/gammaStrahlung/monopoly_app/assets/56844505/96688cbe-1a8e-4864-9036-1a467aa6f3f6)

